### PR TITLE
using sudo to write under /usr

### DIFF
--- a/src/main/python/hydro_sphere/vm_files/hydra_pkgs_install.sh
+++ b/src/main/python/hydro_sphere/vm_files/hydra_pkgs_install.sh
@@ -6,7 +6,7 @@ echo "**** $dst_work_dir"
 echo "==> Run pre script"
 wget https://raw.githubusercontent.com/zeromq/cppzmq/master/zmq.hpp
 #mv zmq.hpp ${dst_work_dir}/hydra-master/src/main/c/zmq
-mv zmq.hpp /usr/include/zmq.hpp
+sudo mv zmq.hpp /usr/include/zmq.hpp
 sudo apt-get -y install python-dev python-pip rabbitmq-server
 
 echo "==> Install RMQ pre-reqs for unit test using mock backend"


### PR DESCRIPTION
On most users /usr/ is owned by root, so sudo should be used to write to it. Executing the whole script  with sudo is not always a good idea because then you end with everything owned by sudo
