### PR TITLE
Making sure deployment_id is non-alphanumeric only

### DIFF
--- a/src/main/python/hydro_sphere/hydro_sphere.py
+++ b/src/main/python/hydro_sphere/hydro_sphere.py
@@ -32,7 +32,6 @@ def validate_deployment_id(deployment_id):
         raise ValueError(exception_msg)
 
 
-
 if __name__ == "__main__":
     deployment_id = validate_deployment_id(args.deployment_id)
     config_file = args.config_file

--- a/src/main/python/hydro_sphere/hydro_sphere.py
+++ b/src/main/python/hydro_sphere/hydro_sphere.py
@@ -1,6 +1,8 @@
 #!/usr/bin/python
 import os
 import argparse
+import re
+from exceptions import ValueError
 
 from config import Config
 from deployment import Deployment
@@ -20,8 +22,19 @@ parser.add_argument('--clean', '-c', action='store_true', help='cleanup instance
 args = parser.parse_args()
 
 
+def validate_deployment_id(deployment_id):
+    # Since hydra depends on dashes and gce api doesn't allow other non-aphanumeric characters
+    # in instance names, don't allow them in deployment_ids
+    if re.match(r"^[a-z0-9]+$", deployment_id):
+        return deployment_id
+    else:
+        exception_msg = "--deployment_id | -i <%s> cannot contain non-alphanumeric characters" % (deployment_id)
+        raise ValueError(exception_msg)
+
+
+
 if __name__ == "__main__":
-    deployment_id = args.deployment_id
+    deployment_id = validate_deployment_id(args.deployment_id)
     config_file = args.config_file
 
     config = Config(deployment_id)


### PR DESCRIPTION
Since hydra depends on dashes and gce api doesn't allow other non-aphanumeric characters
in instance names, don't allow them in deployment_ids

Signed-off-by: Muaaz Saleem muaazsaleem@outlook.com
