### PR TITLE
Using 'set -e' rather than '/bin/bash -e'

### DIFF
--- a/src/main/python/hydro_sphere/vm_files/add_grouping.sh
+++ b/src/main/python/hydro_sphere/vm_files/add_grouping.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/bin/bash
+set -e
 tag=$1
 slave_id=$2
 echo "tag=${tag} and slave_id=${slave_id}"

--- a/src/main/python/hydro_sphere/vm_files/add_mesos_sphere_repo_and_install_java.sh
+++ b/src/main/python/hydro_sphere/vm_files/add_mesos_sphere_repo_and_install_java.sh
@@ -1,4 +1,5 @@
-#! /bin/bash -e
+#! /bin/bash
+set -e
 
 sudo apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF
 DISTRO=$(lsb_release -is | tr '[:upper:]' '[:lower:]')

--- a/src/main/python/hydro_sphere/vm_files/hydra_pkgs_install.sh
+++ b/src/main/python/hydro_sphere/vm_files/hydra_pkgs_install.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/bin/bash
+set -e
 dst_work_dir=$1
 
 echo "**** $dst_work_dir"

--- a/src/main/python/hydro_sphere/vm_files/hydra_pkgs_install_slaves.sh
+++ b/src/main/python/hydro_sphere/vm_files/hydra_pkgs_install_slaves.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 set -e
 
 sudo apt-get install -y python-dev python-pip libtool pkg-config build-essential autoconf automake

--- a/src/main/python/hydro_sphere/vm_files/master_marathon_conf.sh
+++ b/src/main/python/hydro_sphere/vm_files/master_marathon_conf.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/bin/bash
+set -e
 
 # Marathon configuration directory structure we need is not created automatically.
 # We will have to create the directory and then we can copy the file over.

--- a/src/main/python/hydro_sphere/vm_files/srv_init_rules_and_restart_srv.sh
+++ b/src/main/python/hydro_sphere/vm_files/srv_init_rules_and_restart_srv.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/bin/bash
+set -e
 sudo service mesos-slave stop || true
 sudo bash -c "echo 'manual' > /etc/init/mesos-slave.override"
 sudo service zookeeper stop || true


### PR DESCRIPTION
Though command in script was failing, it was not halting and was not returning error.
As an experiment, A script having a command which fails was writtent. After the failing command,
an echo statement was placed.
Script containing "#!/bin/bash -e" printed the echo
While script with "set -e" did not print the echo
Scripts was run using /bin/bash test.sh

p.s: Running script with ./test.sh showed the expected behavior in both cases.
# !/bin/bash -e

false
echo "return value=$?"
echo "I have not returned"
